### PR TITLE
DATA-1612: Remove extra task.on_kill() call

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1382,13 +1382,9 @@ class TaskInstance(Base):
                 # if it goes beyond
                 result = None
                 if task_copy.execution_timeout:
-                    try:
-                        with timeout(int(
-                                task_copy.execution_timeout.total_seconds())):
-                            result = task_copy.execute(context=context)
-                    except AirflowTaskTimeout:
-                        task_copy.on_kill()
-                        raise
+                    with timeout(int(
+                            task_copy.execution_timeout.total_seconds())):
+                        result = task_copy.execute(context=context)
                 else:
                     result = task_copy.execute(context=context)
 


### PR DESCRIPTION
Since user-defined functions `on_handle_failure_callback` and `on_handle_retry_callback` handle failures at an Operator level, the task runner model does not need to issue an `on_kill` command as a result.

The extra `on_kill` will pull an xcomm value that does not exist (since it got deleted on the first pass).

```
[2017-08-14 20:59:29,214] {base_task_runner.py:95} INFO - Subtask: [2017-08-14 20:59:29,213] {models.py:1481} ERROR - 'NoneType' object has no attribute 'xcom_pull'
[2017-08-14 20:59:29,214] {base_task_runner.py:95} INFO - Subtask: Traceback (most recent call last):
[2017-08-14 20:59:29,215] {base_task_runner.py:95} INFO - Subtask:   File "/usr/local/bin/airflow", line 6, in <module>
[2017-08-14 20:59:29,215] {base_task_runner.py:95} INFO - Subtask:     exec(compile(open(__file__).read(), __file__, 'exec'))
[2017-08-14 20:59:29,216] {base_task_runner.py:95} INFO - Subtask:   File "/src/airflow/airflow/bin/airflow", line 28, in <module>
[2017-08-14 20:59:29,216] {base_task_runner.py:95} INFO - Subtask:     args.func(args)
[2017-08-14 20:59:29,217] {base_task_runner.py:95} INFO - Subtask:   File "/src/airflow/airflow/bin/cli.py", line 422, in run
[2017-08-14 20:59:29,217] {base_task_runner.py:95} INFO - Subtask:     pool=args.pool,
[2017-08-14 20:59:29,218] {base_task_runner.py:95} INFO - Subtask:   File "/src/airflow/airflow/utils/db.py", line 53, in wrapper
[2017-08-14 20:59:29,219] {base_task_runner.py:95} INFO - Subtask:     result = func(*args, **kwargs)
[2017-08-14 20:59:29,220] {base_task_runner.py:95} INFO - Subtask:   File "/src/airflow/airflow/models.py", line 1390, in run
[2017-08-14 20:59:29,222] {base_task_runner.py:95} INFO - Subtask:     task_copy.on_kill()
[2017-08-14 20:59:29,222] {base_task_runner.py:95} INFO - Subtask:   File "/src/airflow/airflow/contrib/operators/qubole_operator.py", line 143, in on_kill
[2017-08-14 20:59:29,224] {base_task_runner.py:95} INFO - Subtask:     self.get_hook().kill(ti)
[2017-08-14 20:59:29,224] {base_task_runner.py:95} INFO - Subtask:   File "/src/airflow/airflow/contrib/hooks/qubole_hook.py", line 125, in kill
[2017-08-14 20:59:29,226] {base_task_runner.py:95} INFO - Subtask:     cmd_id = ti.xcom_pull(key="qbol_cmd_id", task_ids=ti.task_id)
[2017-08-14 20:59:29,226] {base_task_runner.py:95} INFO - Subtask: AttributeError: 'NoneType' object has no attribute 'xcom_pull'
```