### PR TITLE
reduce cardinality of datadog tags

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -603,8 +603,11 @@ class SchedulerJob(BaseJob):
                             execution_date=dttm,
                             timestamp=ts))
                         Stats.incr('task_sla_miss', 1, 1, tags=['dag_id:{}'.format(ti.dag_id)])
+                        task_id_entity = '.'.join(ti.task_id.split('.')[:-1])
+                        task_id_action = '.'.join(ti.task_id.split('.')[-1:])
                         Stats.incr('task_sla_miss.by_task', 1, 1, tags=['dag_id:{}'.format(ti.dag_id),
-                                                                        'task_id:{}'.format(ti.task_id)])
+                                                                        'task_id:{}'.format(task_id_entity),
+                                                                        'task_id_action:{}'.format(task_id_action)])
                     dttm = dag.following_schedule(dttm)
         session.commit()
 
@@ -2196,9 +2199,12 @@ class LocalTaskJob(BaseJob):
         ti = self.task_instance
         if ti.state == State.RUNNING:
             Stats.incr('task_heartbeat', 1, 1, tags=['dag_id:{}'.format(self.task_instance.dag_id)])
+            task_id_entity = '.'.join(self.task_instance.task_id.split('.')[:-1])
+            task_id_action = '.'.join(self.task_instance.task_id.split('.')[-1:])
             Stats.incr('task_heartbeat.by_task', 1, 1,
                        tags=['dag_id:{}'.format(self.task_instance.dag_id),
-                             'task_id:{}'.format(self.task_instance.task_id)])
+                             'task_id:{}'.format(task_id_entity),
+                             'task_id_action:{}'.format(task_id_action)])
             self.was_running = True
             fqdn = socket.getfqdn()
             if fqdn != ti.hostname:

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -62,6 +62,17 @@ def ds_format(ds, input_format, output_format):
     return datetime.strptime(ds, input_format).strftime(output_format)
 
 
+def ts_epoch(ts):
+    """
+    Given a datetime, return seconds since epoch
+
+    :param ts: the date to convert
+    :type ts: datetime
+
+    """
+    return int((ts - datetime(1970, 1, 1)).total_seconds())
+
+
 def _integrate_plugins():
     """Integrate plugins to the context"""
     import sys

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1446,7 +1446,7 @@ class TaskInstance(Base):
         session.commit()
 
         if self.queued_dttm and self.start_date:
-            queued_time = (self.queued_dttm - self.start_date).total_seconds()
+            queued_time = (self.start_date - self.queued_dttm).total_seconds()
             stats_gauge_helper('task_queue_lag', queued_time, self.dag_id, self.task_id)
 
         # Success callback


### PR DESCRIPTION
We were writing too many task_ids.  Reduce the cardinality by splitting the ids into subject and action.
