### PR TITLE
Add dag duration metric

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -159,6 +159,8 @@ class DagFileProcessor(AbstractDagFileProcessor, LoggingMixin, MultiprocessingSt
                                                 pickle_dags)
             result_channel.send(result)
             end_time = time.time()
+            file_name = os.path.basename(file_path)
+            Stats.timing('dag_processing.duration.{}'.format(file_name), end_time - start_time)
             log.info(
                 "Processing %s took %.3f seconds", file_path, end_time - start_time
             )

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -95,7 +95,8 @@ Name                                        Description
 =========================================== =================================================
 ``dagrun.dependency-check.<dag_id>``        Milliseconds taken to check DAG dependencies
 ``dag.<dag_id>.<task_id>.duration``         Milliseconds taken to finish a task
-``dag_processing.last_duration.<dag_file>`` Milliseconds taken to load the given DAG file
+``dag_processing.duration.<dag_file>``      Milliseconds taken to load the given DAG file
+``dag_processing.last_duration.<dag_file>`` Milliseconds taken to load the given DAG file on previous run
 ``dagrun.duration.success.<dag_id>``        Milliseconds taken for a DagRun to reach success state
 ``dagrun.duration.failed.<dag_id>``         Milliseconds taken for a DagRun to reach failed state
 ``dagrun.schedule_delay.<dag_id>``          Milliseconds of delay between the scheduled DagRun


### PR DESCRIPTION
The current last_duration stat only reports during the 30 seconds report stats interval which we don't print very often



