### PR TITLE
Re-add zombies_killed metric

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -355,6 +355,7 @@ class DagBag(BaseDagBag, LoggingMixin):
                     ti.handle_failure("{} detected as zombie".format(ti),
                                       ti.test_mode, ti.get_template_context())
                     self.log.info('Marked zombie job %s as %s', ti, ti.state)
+                    Stats.incr('zombies_killed')
         session.commit()
 
     def bag_dag(self, dag, parent_dag, root_dag):


### PR DESCRIPTION
Looks like it was accidentally removed from Airflow? 

https://github.com/apache/airflow/pull/5511/files#diff-a2cc1cc05747aab5c8f90ce72a599322d32f69fbfa1e9474655f0471d500e2dfR312

