### PR TITLE
DATA-5506 Add dag tag support to home page (copied from rbac index.html)

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -33,13 +33,16 @@
   <div id="main_content">
     <div class="row">
       <div class="col-sm-2">
+        <form id="filter_form" class="form-inline" style="width: 100%; text-align: left; float: right;">
+            <input type="submit" value="Reset Tag Filter" class="btn btn-default" name="reset_tags">
+        </form>
       </div>
       <div class="col-sm-10">
-        <form id="search_form" class="form-inline" style="width: 100%; text-align: right;">
-            <div id="dags_filter" class="form-group" style="width: 100%;">
-              <label for="dag_query" style="width:20%; text-align: right;">Search:</label>
-              <input id="dag_query" type="text" class="typeahead form-control" data-provide="typeahead" style="width:50%;" value="{{search_query}}">
-            </div>
+        <form id="search_form" class="form-inline" style="width: 100%; text-align: right; float: right;">
+          <div id="dags_filter" class="form-group" style="width: 100%;">
+            <label for="dag_query" style="width:20%; text-align: right;">Search:</label>
+            <input id="dag_query" type="text" class="typeahead form-control" data-provide="typeahead" style="width:50%;" value="{{search_query}}" autocomplete="off">
+          </div>
         </form>
       </div>
     </div>
@@ -81,10 +84,22 @@
 
                 <!-- Column 3: Name -->
                 <td>
-                  <a href="{{ url_for('airflow.'+ dag.get_default_view(), dag_id=dag.dag_id) }}"
-                         title="{{ dag.description[0:80] + '...' if dag.description and dag.description|length > 80 else dag.description|default('', true) }}">
-                          {{ dag.dag_id }}
-                  </a>
+                  <span>
+                    <a href="{{ url_for('airflow.'+ dag.get_default_view(), dag_id=dag.dag_id) }}"
+                           title="{{ dag.description[0:80] + '...' if dag.description and dag.description|length > 80 else dag.description|default('', true) }}">
+                            {{ dag.dag_id }}
+                    </a>
+                  </span>
+
+                  <div style="float: right; max-width: 70%; text-align: right; line-height: 160%;">
+                    {% for tag in dag.tags | sort(attribute='name') %}
+                      <a class="label label-success"
+                         href="?tags={{ tag.name }}"
+                         style="margin: 3px;">
+                         {{ tag.name }}
+                      </a>
+                    {% endfor %}
+                  </div>
                 </td>
 
                 <!-- Column 4: Dag Schedule -->

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1699,10 +1699,13 @@ class Airflow(AirflowViewMixin, BaseView):
 
         root = request.args.get('root')
         if root:
+            rel = request.args.get('rel')
+            include_upstream = False if rel == "downstream" else True
+            include_downstream = False if rel == "upstream" else True
             dag = dag.sub_dag(
                 task_regex=root,
-                include_upstream=True,
-                include_downstream=False)
+                include_upstream=include_upstream,
+                include_downstream=include_downstream)
 
         arrange = request.args.get('arrange', dag.orientation)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -39,7 +39,7 @@ import sqlalchemy as sqla
 import pendulum
 from flask import (
     abort, jsonify, redirect, url_for, request, Markup, Response,
-    current_app, render_template, make_response)
+    current_app, render_template, make_response, session as flask_session)
 from flask import flash
 from flask_admin import BaseView, expose, AdminIndexView
 from flask_admin.actions import action
@@ -57,7 +57,8 @@ import six
 from pygments.formatters.html import HtmlFormatter
 from six.moves.urllib.parse import quote, unquote, urlparse
 
-from sqlalchemy import or_, desc, and_, union_all
+from sqlalchemy import or_, desc, func, and_, union_all
+from sqlalchemy.orm import joinedload
 from wtforms import (
     Form, SelectField, TextAreaField, PasswordField,
     StringField, IntegerField, validators)
@@ -73,6 +74,7 @@ from airflow.api.common.experimental.mark_tasks import (set_dag_run_state_to_run
                                                         set_dag_run_state_to_failed)
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, Connection, DagRun, errors, XCom
+from airflow.models.dag import DagTag
 from airflow.models.dagcode import DagCode
 from airflow.settings import STATE_COLORS, STORE_SERIALIZED_DAGS
 from airflow.operators.subdag_operator import SubDagOperator
@@ -104,6 +106,7 @@ logout_user = airflow.login.logout_user
 FILTER_BY_OWNER = False
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
+FILTER_TAGS_COOKIE = 'tags_filter'
 
 log = logging.getLogger(__name__)
 
@@ -2258,6 +2261,17 @@ class HomeView(AirflowViewMixin, AdminIndexView):
 
         arg_current_page = request.args.get('page', '0')
         arg_search_query = request.args.get('search', None)
+        arg_tags_filter = request.args.getlist('tags', None)
+
+        if request.args.get('reset_tags') is not None:
+            flask_session[FILTER_TAGS_COOKIE] = None
+            arg_tags_filter = None
+        else:
+            cookie_val = flask_session.get(FILTER_TAGS_COOKIE)
+            if arg_tags_filter:
+                flask_session[FILTER_TAGS_COOKIE] = ','.join(arg_tags_filter)
+            elif cookie_val:
+                arg_tags_filter = cookie_val.split(',')
 
         dags_per_page = PAGE_SIZE
         current_page = get_int_arg(arg_current_page, default=0)
@@ -2298,12 +2312,16 @@ class HomeView(AirflowViewMixin, AdminIndexView):
                 DM.owners.ilike('%' + arg_search_query + '%')
             )
 
+        if arg_tags_filter:
+            query = query.filter(DM.tags.any(DagTag.name.in_(arg_tags_filter)))
+
         query = query.order_by(DM.dag_id)
 
         start = current_page * dags_per_page
         end = start + dags_per_page
 
-        dags = query.offset(start).limit(dags_per_page).all()
+        dags = query.order_by(DM.dag_id).options(
+            joinedload(DM.tags)).offset(start).limit(dags_per_page).all()
 
         import_errors = session.query(errors.ImportError).all()
         for ie in import_errors:


### PR DESCRIPTION
# What
Add Dag tags support for the home page UI to display and enable filtering by tag.

![Screen Shot 2021-03-25 at 4 57 49 PM](https://user-images.githubusercontent.com/134710/112558282-a0a3ec00-8d8b-11eb-834f-bcee564c3c84.png)

![Screen Shot 2021-03-25 at 4 50 34 PM](https://user-images.githubusercontent.com/134710/112557667-3d658a00-8d8a-11eb-8483-a61542eecc55.png)

# Why
I plan to use these tags for backfills to filter by completed/queued/running/blocked state for the backfill cost approval tool.

# How
By [copying the functionality from rbac](https://airflow.apache.org/docs/apache-airflow/stable/howto/add-dag-tags.html) index.html file and modifying it slightly. DagTag already exists in the db but they were not being exposed or filtered in our index view/html file.
The tag filters uses cookies so it will follow wherever unless you hit the Reset Tags Filter button on the home page. Adding multiple tags is done with `?tags=blah&tags=blah2` and they use an OR expression per the current Airflow behavior.

This will likely make any upgrades of this file more difficult for the next person, but I figure that our next upgrade will be to 2.0 which is a whole other thing.

# Test
- [x] staging manual testing - currently running there
- [x] local manual testing - had my local point at airflow repo and lots of webserver restarts