### PR TITLE
remove backfills from home page

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2287,7 +2287,8 @@ class HomeView(AirflowViewMixin, AdminIndexView):
             hide_paused = hide_paused_dags_by_default
 
         # read orm_dags from the db
-        query = session.query(DM)
+        query = session.query(DM).filter(
+            ~DM.dag_id.ilike('zz__backfill__%'))
 
         if do_filter and owner_mode == 'ldapgroup':
             query = query.filter(


### PR DESCRIPTION
As part of the backfill cost wall, remove backfills from the main home page dag list.

I don't love hard-coding the backfills dag prefix here (this will break if we rename backfills), but I couldn't think of a better way across repos. Airflow has a way to check if a dag is a backfill, but it doesn't work for our homemade backfills.

Before:
![Screen Shot 2021-04-05 at 10 26 18 AM](https://user-images.githubusercontent.com/134710/113604304-eec1b680-95f9-11eb-88d4-96ee58a19db0.png)

After:
![Screen Shot 2021-04-05 at 10 27 07 AM](https://user-images.githubusercontent.com/134710/113604300-ed908980-95f9-11eb-8095-7aea4101e906.png)
