### PR TITLE
Add a task search modal to quickly navigate to any Airflow task

### DIFF
--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -35,6 +35,7 @@
 {% block tail_js %}
 {{ super() }}
 <script src="{{ url_for('static', filename='jqClock.min.js') }}" type="text/javascript"></script>
+<script src="{{ url_for('static', filename='bootstrap3-typeahead.min.js') }}"></script>
 <script>
     x = new Date()
     var UTCseconds = (x.getTime() + x.getTimezoneOffset()*60*1000);
@@ -126,10 +127,81 @@ function convertSecsToHumanReadable(seconds) {
    }
    return readableFormat
 }
+
+// Capture keyboard shortcuts
+$(document).keyup(function(e) {
+  if (!/^(?:input|textarea|select|button)$/i.test(e.target.tagName)) {
+    let key = e.which || e.keyCode;
+    let letterT = 84;
+    if (key === letterT) {
+      initTaskSearchModal();
+    }
+  }
+});
+
+function initTaskSearchModal() {
+  let taskSearchInput = $("#task_query");
+  $.getJSON("{{ url_for('airflow.all_tasks') }}", function (data) {
+    $('.typeahead').typeahead('destroy');
+    taskSearchInput.typeahead({
+      source: data,
+      items: 20,
+      afterSelect: function (value) {
+        $('#taskFinderGraph').attr('href', "{{ url_for('airflow.graph') }}"
+          + "?dag_id=" + encodeURI(value.dag_id)
+          + "&root=" + encodeURI(value.task_id));
+        $('#taskFinderTree').attr('href', "{{ url_for('airflow.tree') }}"
+          + "?dag_id=" + encodeURI(value.dag_id)
+          + "&root=" + encodeURI(value.task_id))
+        .focus();
+      }
+    });
+
+    $("#taskFinderModal").on('shown.bs.modal', function () {
+        taskSearchInput.focus();
+      })
+      .modal({})
+      .css("margin-top", "0px");
+  });
+};
 </script>
 {% endblock %}
 
 {% block page_body %}
+<!-- Modal for task finder -->
+<div class="modal fade" id="taskFinderModal"
+      tabindex="-1" role="dialog"
+    aria-labelledby="dagModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="taskFinderModalLabel">
+          <span id='taskFinderSearch'>Task Search</span>
+        </h4>
+      </div>
+      <div class="modal-body">
+          <label for="task_query" style="display: none;">Search</label>
+          <input id="task_query" type="text" class="task-typeahead form-control" data-provide="typeahead"
+                 value="" autocomplete="off">
+      </div>
+      <div class="modal-footer">
+
+        <ul class="nav nav-pills">
+          <li><a id="taskFinderTree" href="#">
+              <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
+            Tree View</a></li>
+          <li><a id="taskFinderGraph" href="#">
+              <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
+            Graph View</a></li>
+          <li><a href="#" data-dismiss="modal">
+            Close
+            </a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="container">
 
 <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation" style="background-color: {{ navbar_color }};">

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -53,6 +53,12 @@
     <li><a href="{{ url_for("airflow.xcom", dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
         <span class="glyphicon glyphicon-certificate" aria-hidden="true"></span>
       XCom</a></li>
+    <li><a href="{{ url_for("airflow.graph", dag_id=dag.dag_id, root=task_id) }}">
+        <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
+      Graph View</a></li>
+    <li><a href="{{ url_for("airflow.tree", dag_id=dag.dag_id, root=task_id) }}">
+        <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
+      Tree View</a></li>
   </ul>
   <hr>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1349,6 +1349,16 @@ class Airflow(AirflowViewMixin, BaseView):
         return self._clear_dag_tis(dag, start_date, end_date, origin,
                                    recursive=recursive, confirmed=confirmed, only_failed=only_failed)
 
+    @expose('/all_tasks', methods=['GET'])
+    @login_required
+    def all_tasks(self):
+        payload = []
+        for _, dag in dagbag.dags.items():
+            for task in dag.tasks:
+                payload.append({'dag_id': dag.dag_id, 'task_id': task.task_id, 'name': f'{dag.dag_id} {task.task_id}'})
+        payload.sort(key=lambda x: x['name'])
+        return wwwutils.json_response(payload)
+
     @expose('/dagrun_clear', methods=['POST'])
     @login_required
     @wwwutils.action_logging


### PR DESCRIPTION
# What
Open up a modal from any Airflow page by pressing `t` (not in a text area) that immediately lets you type a task id and autocompletes. Once selected, press enter again to go to a filtered tree view or tab + enter to go to a filtered graph view.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/134710/114435835-7cad1c80-9b79-11eb-8c7d-dd5339c14fe9.gif)

# Why
I've always thought there is too much clicking around when trying to navigate through Airflow. Hopefully this helps save everyone some time!

# How
By exposing an endpoint that returns all task ids from the DagBag, which is already loaded into memory on the webserver so is pretty fast (locally was around 20-30ms). The javascript catches keystrokes outside of text input areas and then opens the modal, calling the webserver. The autofill uses the same autofiller that Airflow uses for searches on the home page.

# Testing
Tested in Chrome only, no automated tests