### PR TITLE
Use gzip on dag_stats endpoint

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -590,6 +590,7 @@ class Airflow(AirflowViewMixin, BaseView):
 
     @expose('/dag_stats')
     @login_required
+    @wwwutils.gzipped
     @provide_session
     def dag_stats(self, session=None):
         dr = models.DagRun


### PR DESCRIPTION
In an extreme case in prod, you can see that waiting for the almost 1mb of data can take 500ms-1s that could be shaved off with gzip, hopefully making the home page and the backfill page a little snappier.

![Screen Shot 2021-04-29 at 11 01 25 AM](https://user-images.githubusercontent.com/134710/116597426-7689a080-a8da-11eb-97d9-5bcf9baeb022.png)
