### PR TITLE
Celery workers to not check for hearbeat of its peers

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -2528,12 +2528,12 @@ class CLIFactory(object):
             help=("Set the hostname of celery worker "
                   "if you have multiple workers on a single machine.")),
         'without_mingle': Arg(
-            ("--without-mingle"),
+            ("--without-mingle",),
             default=False,
             help="Don’t synchronize with other workers at start-up",
             action="store_true"),
         'without_gossip': Arg(
-            ("--without-gossip"),
+            ("--without-gossip",),
             default=False,
             help="Don’t subscribe to other workers events",
             action="store_true"),

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1277,6 +1277,8 @@ def worker(args):
         'autoscale': autoscale,
         'hostname': args.celery_hostname,
         'loglevel': conf.get('core', 'LOGGING_LEVEL'),
+        'without_mingle': args.without_mingle,
+        'without_gossip': args.without_gossip,
     }
 
     if conf.has_option("celery", "pool"):

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -2525,6 +2525,16 @@ class CLIFactory(object):
             ("-cn", "--celery_hostname"),
             help=("Set the hostname of celery worker "
                   "if you have multiple workers on a single machine.")),
+        'without_mingle': Arg(
+            ("--without-mingle"),
+            default=False,
+            help="Don’t synchronize with other workers at start-up",
+            action="store_true"),
+        'without_gossip': Arg(
+            ("--without-gossip"),
+            default=False,
+            help="Don’t subscribe to other workers events",
+            action="store_true"),
         # flower
         'broker_api': Arg(("-a", "--broker_api"), help="Broker api"),
         'flower_hostname': Arg(
@@ -2815,7 +2825,8 @@ class CLIFactory(object):
             'func': worker,
             'help': "Start a Celery worker node",
             'args': ('do_pickle', 'queues', 'concurrency', 'celery_hostname',
-                     'pid', 'daemon', 'stdout', 'stderr', 'log_file', 'autoscale', 'skip_serve_logs'),
+                     'pid', 'daemon', 'stdout', 'stderr', 'log_file', 'autoscale', 'skip_serve_logs',
+                     'without_mingle', 'without_gossip'),
         }, {
             'func': flower,
             'help': "Start a Celery Flower",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -645,7 +645,9 @@ class TestWorkerStart(unittest.TestCase):
             '--celery_hostname',
             celery_hostname,
             '--queues',
-            queues
+            queues,
+            '--without-mingle',
+            '--without-gossip',
         ])
 
         with mock.patch('celery.platforms.check_privileges') as mock_privil:
@@ -661,6 +663,8 @@ class TestWorkerStart(unittest.TestCase):
             autoscale=autoscale,
             hostname=celery_hostname,
             loglevel=mock.ANY,
+            without_mingle=True,
+            without_gossip=True,
         )
 
 


### PR DESCRIPTION
Backport PR - https://github.com/apache/airflow/pull/13880

Tested locally by updating dataflow to this branch. 

* The airflow worker command now has the two new arguments
<img width="553" alt="Screen Shot 2021-05-14 at 4 50 50 PM" src="https://user-images.githubusercontent.com/73497410/118342446-47794e80-b4d8-11eb-8e83-844d37a81458.png">

* The worker when boots up has these two args and its running without errors.
<img width="904" alt="Screen Shot 2021-05-14 at 5 10 57 PM" src="https://user-images.githubusercontent.com/73497410/118342548-9d4df680-b4d8-11eb-8619-abfc60830ef5.png">


**Next steps:**

* Update dataflow's ecs woerk task defn to have the --without-mingle and --without-gossip args
